### PR TITLE
Can use dns name in DEST_IP value

### DIFF
--- a/entry
+++ b/entry
@@ -9,6 +9,8 @@ if [ `cat /proc/sys/net/ipv4/ip_forward` != 1 ]; then
     exit 1
 fi
 
+DEST_IP=`getent hosts $DEST_IP | cut -f1 -d' '`
+
 iptables -t nat -I PREROUTING ! -s ${DEST_IP}/32 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${DEST_IP}:${DEST_PORT}
 iptables -t nat -I POSTROUTING -d ${DEST_IP}/32 -p ${DEST_PROTO} -j MASQUERADE
 


### PR DESCRIPTION
This PR just add dns resolution in _/entry_ script.
So, you can use DNS name in DEST_IP value.
Exemple : 
        - name: DEST_IP
          value: traefik.traefik.svc.cluster.local
